### PR TITLE
encourage non-directory script dependencies

### DIFF
--- a/R/createMakefiles.R
+++ b/R/createMakefiles.R
@@ -195,18 +195,43 @@ createMakeBlockRules <- function(block=c('fetch','process','visualize','publish'
   # read information about this block from viz.yaml
   content.info <- getContentInfos(block=block)
 
+  # check for and warn about dependencies on directories
+  dir.deps <- unlist(lapply(content.info, function(cinfo) {
+    is.dir <- sapply(cinfo$scripts, dir.exists)
+    names(is.dir)[is.dir]
+  }))
+  if(length(dir.deps) > 0) {
+    dir.deps.info <- sapply(unique(dir.deps), function(dependency) {
+      dependers <- names(dir.deps)[dir.deps == dependency]
+      sprintf("* Items depending on the %s directory: %s", dependency, paste(dependers, collapse=', '))
+    }, USE.NAMES=FALSE)
+    dir.deps.msg <- c(
+      '-----WARNING-----',
+      paste("Script dependencies should be specific files to avoid Making items too seldom or too often.",
+            "You can override the default (a directory) by setting 'scripts' in each viz.yaml item."),
+      paste0(dir.deps.info, collapse='\n'), 
+      '-----------------')
+  } else {
+    dir.deps.msg <- NULL
+  }
+  
   # set the 'all' target to include all content items
   all <- createMakeEmptyRule(
     target='all',
-    depends=paste0("\\\n\t", sapply(content.info, `[[`, 'id')))
+    depends=paste0("\\\n\t", c(sapply(content.info, `[[`, 'id'), 'MakeMessages')))
 
   # write the rules for each content item
   items <- sapply(content.info, function(item.info) {
     createMakeItem(item.info)
   })
+  
+  # write any messages the user should see on calling 'make' - so far this is
+  # just the directory dependencies issues if present
+  if(length(dir.deps.msg) == 0) dir.deps.msg <- paste0(block, ".make looks OK!")
+  messages <- createMakeShellRule('MakeMessages', c(), paste0('@echo "', c('', dir.deps.msg, ''), '"'))
 
   # combine all the targets into a single string
-  paste(c(list("# Rules", all), items), collapse='\n\n')
+  paste(c(list("# Rules", all), items, list(messages)), collapse='\n\n')
 }
 
 #' Make a collection of makefile rules appropriate to a data/figure item

--- a/inst/doc/vizlabExample.Rmd
+++ b/inst/doc/vizlabExample.Rmd
@@ -37,7 +37,7 @@ To build the example viz, your working directory should be set to the main examp
 
 ### Info
 ```
-vizlab: "0.1.4"
+vizlab: "0.1.5"
 info:
   id: example
   name: Simple but complete vizualization
@@ -60,17 +60,20 @@ fetch:
     id: iris-data
     location: data/iris.csv
     mimetype: text/csv
+    scripts:
     refetch: TRUE
   -
     id: cars-data
     location: cache/cars.csv
     fetcher: cars
     mimetype: text/csv
+    scripts: scripts/fetch/cars.R
     refetch: TRUE
   -
     id: Cuyahoga
     location: cache/fetch/CuyahogaTDS.csv
     fetcher: sciencebase
+    scripts:
     refetch: TRUE
     remoteItemId: 575d839ee4b04f417c2a03fe
     remoteFilename: CuyahogaTDS.csv
@@ -83,10 +86,11 @@ Three possibilites for fetchers are utilized here. `iris-data` is a local file a
 ### Process
 ```
 process:
- -
+  -
     id: calc-cars
     location: cache/car-loess.rds
     processor: cars
+    scripts: scripts/process/cars.R
     reader: rds
     depends: [ "cars-data" ]
   -
@@ -95,6 +99,7 @@ process:
     mimetype: text/tab-separated-values
     depends: Cuyahoga
     processor: cuyahoga
+    scripts: scripts/process/cuyahoga.R
 ```
 `depends` references the IDs in the fetch section.  All processors must be supplied by the user.  Just as the custom fetchers are stored in `scripts/fetch`, processors are stored in `scripts/process`. The output of each processor is stored in the directory specified by the `location` field.  The `reader` specified will be used to read in the data for the visualize step.  Note the `calc-cars` step indicates a specific .Rds reader, rather than a mimetype.  The readers included in the vizlab package are located in the `readData` S3 method.  Alternatively, a custom reader could be specified, that should be located in the `scripts/process` directory.  
 
@@ -106,14 +111,16 @@ visualize:
   -
     id: plot-cars
     location: figures/cars.png
+    scripts: scripts/visualize/visualize.R
     visualizer: cars
     depends: [ "calc-cars", "cars-data" ]
     mimetype: image/png
-    title: "Speed vs. Breaking Distance"
-    alttext: "plot of ratio of speed to breaking distance"
+    title: "Speed vs. Braking Distance"
+    alttext: "plot of ratio of speed to braking distance"
   -
     id: plot-iris
     location: figures/iris.png
+    scripts: scripts/visualize/visualize.R
     visualizer: iris
     depends: [ "iris-data" ]
     mimetype: image/png
@@ -123,6 +130,7 @@ visualize:
     id: cuyahogaFig
     location: figures/cuyahogaFig.svg
     depends: "CuyahogaShort"
+    scripts: scripts/visualize/visualize.R
     visualizer: qTDS
     mimetype: image/svg+xml
     title: "Cuyahoga figure"
@@ -206,52 +214,91 @@ The following steps are required to start a viz from scratch.  The first two hav
   Finally, execute all the created make files by running `make` from the terminal in the main example viz directory:
 ```
 <terminal prompt>:~/Documents/R/example_viz$ make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
+$ make
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
 make -f vizlab/make/fetch.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='Cuyahoga') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='iris-data')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='iris-data')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='Cuyahoga')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='Cuyahoga')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga.Rout
+
+fetch.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
 make -f vizlab/make/process.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process')" \
-	vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='CuyahogaShort') scripts=c('scripts/process/cuyahoga.R')" \
+vizlab/make/callFunction.R vizlab/make/log/process/CuyahogaShort.Rout
+
+process.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
 make -f vizlab/make/visualize.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize')" \
-	vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-iris') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-iris.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='cuyahogaFig') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/cuyahogaFig.Rout
+
+visualize.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
 make -f vizlab/make/publish.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='index')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='cars-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='text-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='iris-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='Cuyahoga-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='index')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='cars-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='text-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='iris-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='Cuyahoga-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout
+
+publish.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
 ```
 This will call the main makefile, which in turn calls the makefile for each section.  The finished HTML will be created in the `target` directory, along with its corresponding CSS and images for each figure.  
 

--- a/inst/doc/vizlabExample.html
+++ b/inst/doc/vizlabExample.html
@@ -12,7 +12,7 @@
 
 <meta name="author" content="David Watkins" />
 
-<meta name="date" content="2016-11-19" />
+<meta name="date" content="2016-11-21" />
 
 <title>Vizlab Example</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Vizlab Example</h1>
 <h4 class="author"><em>David Watkins</em></h4>
-<h4 class="date"><em>2016-11-19</em></h4>
+<h4 class="date"><em>2016-11-21</em></h4>
 
 
 
@@ -95,7 +95,7 @@ devtools::<span class="kw">install.github</span>(<span class="st">'USGS-VIZLAB/v
 </div>
 <div id="info" class="section level3">
 <h3>Info</h3>
-<pre><code>vizlab: &quot;0.1.4&quot;
+<pre><code>vizlab: &quot;0.1.5&quot;
 info:
   id: example
   name: Simple but complete vizualization
@@ -116,17 +116,20 @@ info:
     id: iris-data
     location: data/iris.csv
     mimetype: text/csv
+    scripts:
     refetch: TRUE
   -
     id: cars-data
     location: cache/cars.csv
     fetcher: cars
     mimetype: text/csv
+    scripts: scripts/fetch/cars.R
     refetch: TRUE
   -
     id: Cuyahoga
     location: cache/fetch/CuyahogaTDS.csv
     fetcher: sciencebase
+    scripts:
     refetch: TRUE
     remoteItemId: 575d839ee4b04f417c2a03fe
     remoteFilename: CuyahogaTDS.csv
@@ -137,10 +140,11 @@ info:
 <div id="process" class="section level3">
 <h3>Process</h3>
 <pre><code>process:
- -
+  -
     id: calc-cars
     location: cache/car-loess.rds
     processor: cars
+    scripts: scripts/process/cars.R
     reader: rds
     depends: [ &quot;cars-data&quot; ]
   -
@@ -148,7 +152,8 @@ info:
     location: cache/process/CuyahogaShort.tsv
     mimetype: text/tab-separated-values
     depends: Cuyahoga
-    processor: cuyahoga</code></pre>
+    processor: cuyahoga
+    scripts: scripts/process/cuyahoga.R</code></pre>
 <p><code>depends</code> references the IDs in the fetch section. All processors must be supplied by the user. Just as the custom fetchers are stored in <code>scripts/fetch</code>, processors are stored in <code>scripts/process</code>. The output of each processor is stored in the directory specified by the <code>location</code> field. The <code>reader</code> specified will be used to read in the data for the visualize step. Note the <code>calc-cars</code> step indicates a specific .Rds reader, rather than a mimetype. The readers included in the vizlab package are located in the <code>readData</code> S3 method. Alternatively, a custom reader could be specified, that should be located in the <code>scripts/process</code> directory.</p>
 <p>A processing step is not mandatory — the <code>iris-data</code> plot uses only the raw data, so it has no section here.</p>
 </div>
@@ -158,14 +163,16 @@ info:
   -
     id: plot-cars
     location: figures/cars.png
+    scripts: scripts/visualize/visualize.R
     visualizer: cars
     depends: [ &quot;calc-cars&quot;, &quot;cars-data&quot; ]
     mimetype: image/png
-    title: &quot;Speed vs. Breaking Distance&quot;
-    alttext: &quot;plot of ratio of speed to breaking distance&quot;
+    title: &quot;Speed vs. Braking Distance&quot;
+    alttext: &quot;plot of ratio of speed to braking distance&quot;
   -
     id: plot-iris
     location: figures/iris.png
+    scripts: scripts/visualize/visualize.R
     visualizer: iris
     depends: [ &quot;iris-data&quot; ]
     mimetype: image/png
@@ -175,6 +182,7 @@ info:
     id: cuyahogaFig
     location: figures/cuyahogaFig.svg
     depends: &quot;CuyahogaShort&quot;
+    scripts: scripts/visualize/visualize.R
     visualizer: qTDS
     mimetype: image/svg+xml
     title: &quot;Cuyahoga figure&quot;
@@ -254,52 +262,91 @@ info:
 <h2>make</h2>
 <p>Finally, execute all the created make files by running <code>make</code> from the terminal in the main example viz directory:</p>
 <pre><code>&lt;terminal prompt&gt;:~/Documents/R/example_viz$ make
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
+$ make
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
 make -f vizlab/make/fetch.make
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetchTimestamp funargs=list(viz='Cuyahoga') scripts=c('scripts/fetch')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetchTimestamp funargs=list(viz='iris-data')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data_timestamp.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetch funargs=list(viz='iris-data')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetchTimestamp funargs=list(viz='Cuyahoga')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=fetch funargs=list(viz='Cuyahoga')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga.Rout
+
+fetch.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
 make -f vizlab/make/process.make
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process/cars.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=process funargs=list(viz='CuyahogaShort') scripts=c('scripts/process/cuyahoga.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/process/CuyahogaShort.Rout
+
+process.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
 make -f vizlab/make/visualize.make
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize/visualize.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=visualize funargs=list(viz='plot-iris') scripts=c('scripts/visualize/visualize.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-iris.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=visualize funargs=list(viz='cuyahogaFig') scripts=c('scripts/visualize/visualize.R')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/visualize/cuyahogaFig.Rout
+
+visualize.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
 make -f vizlab/make/publish.make
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='index')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='cars-section')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='text-section')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='iris-section')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
-export R_LIBS_USER=&quot;/Users/wwatkins/Library/R/3.3/library&quot;;\
-    &quot;/usr/local/bin/R&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='Cuyahoga-section')&quot; \
-    vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout</code></pre>
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='index')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='cars-section')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='text-section')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='iris-section')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
+export R_LIBS_USER=&quot;C:/Users/aappling/Documents/R/win-library/3.3&quot;;\
+&quot;C:/Program Files/R/R-3.3.2/bin/x64/R.exe&quot; CMD BATCH --no-timing --quiet --no-save --no-restore &quot;--args fun=publish funargs=list(viz='Cuyahoga-section')&quot; \
+vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout
+
+publish.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'</code></pre>
 <p>This will call the main makefile, which in turn calls the makefile for each section. The finished HTML will be created in the <code>target</code> directory, along with its corresponding CSS and images for each figure.</p>
 <div id="debugging" class="section level3">
 <h3>Debugging</h3>

--- a/inst/testviz/viz.yaml
+++ b/inst/testviz/viz.yaml
@@ -50,6 +50,7 @@ fetch:
     location: cache/fetch/CuyahogaTDS.csv
     fetcher: sciencebase
     refetch: false
+    scripts:
     remoteItemId: 575d839ee4b04f417c2a03fe
     remoteFilename: CuyahogaTDS.csv
     mimetype: text/csv

--- a/vignettes/vizlabExample.Rmd
+++ b/vignettes/vizlabExample.Rmd
@@ -37,7 +37,7 @@ To build the example viz, your working directory should be set to the main examp
 
 ### Info
 ```
-vizlab: "0.1.4"
+vizlab: "0.1.5"
 info:
   id: example
   name: Simple but complete vizualization
@@ -60,17 +60,20 @@ fetch:
     id: iris-data
     location: data/iris.csv
     mimetype: text/csv
+    scripts:
     refetch: TRUE
   -
     id: cars-data
     location: cache/cars.csv
     fetcher: cars
     mimetype: text/csv
+    scripts: scripts/fetch/cars.R
     refetch: TRUE
   -
     id: Cuyahoga
     location: cache/fetch/CuyahogaTDS.csv
     fetcher: sciencebase
+    scripts:
     refetch: TRUE
     remoteItemId: 575d839ee4b04f417c2a03fe
     remoteFilename: CuyahogaTDS.csv
@@ -83,10 +86,11 @@ Three possibilites for fetchers are utilized here. `iris-data` is a local file a
 ### Process
 ```
 process:
- -
+  -
     id: calc-cars
     location: cache/car-loess.rds
     processor: cars
+    scripts: scripts/process/cars.R
     reader: rds
     depends: [ "cars-data" ]
   -
@@ -95,6 +99,7 @@ process:
     mimetype: text/tab-separated-values
     depends: Cuyahoga
     processor: cuyahoga
+    scripts: scripts/process/cuyahoga.R
 ```
 `depends` references the IDs in the fetch section.  All processors must be supplied by the user.  Just as the custom fetchers are stored in `scripts/fetch`, processors are stored in `scripts/process`. The output of each processor is stored in the directory specified by the `location` field.  The `reader` specified will be used to read in the data for the visualize step.  Note the `calc-cars` step indicates a specific .Rds reader, rather than a mimetype.  The readers included in the vizlab package are located in the `readData` S3 method.  Alternatively, a custom reader could be specified, that should be located in the `scripts/process` directory.  
 
@@ -106,14 +111,16 @@ visualize:
   -
     id: plot-cars
     location: figures/cars.png
+    scripts: scripts/visualize/visualize.R
     visualizer: cars
     depends: [ "calc-cars", "cars-data" ]
     mimetype: image/png
-    title: "Speed vs. Breaking Distance"
-    alttext: "plot of ratio of speed to breaking distance"
+    title: "Speed vs. Braking Distance"
+    alttext: "plot of ratio of speed to braking distance"
   -
     id: plot-iris
     location: figures/iris.png
+    scripts: scripts/visualize/visualize.R
     visualizer: iris
     depends: [ "iris-data" ]
     mimetype: image/png
@@ -123,6 +130,7 @@ visualize:
     id: cuyahogaFig
     location: figures/cuyahogaFig.svg
     depends: "CuyahogaShort"
+    scripts: scripts/visualize/visualize.R
     visualizer: qTDS
     mimetype: image/svg+xml
     title: "Cuyahoga figure"
@@ -206,52 +214,91 @@ The following steps are required to start a viz from scratch.  The first two hav
   Finally, execute all the created make files by running `make` from the terminal in the main example viz directory:
 ```
 <terminal prompt>:~/Documents/R/example_viz$ make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
+$ make
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='fetch',outfile='vizlab/make/fetch.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/fetch.Rout
 make -f vizlab/make/fetch.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='Cuyahoga') scripts=c('scripts/fetch')" \
-	vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='iris-data')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='iris-data')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/iris-data.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='cars-data') scripts=c('scripts/fetch/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/cars-data.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetchTimestamp funargs=list(viz='Cuyahoga')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga_timestamp.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=fetch funargs=list(viz='Cuyahoga')" \
+vizlab/make/callFunction.R vizlab/make/log/fetch/Cuyahoga.Rout
+
+fetch.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='process',outfile='vizlab/make/process.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/process.Rout
 make -f vizlab/make/process.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process')" \
-	vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='calc-cars') scripts=c('scripts/process/cars.R')" \
+vizlab/make/callFunction.R vizlab/make/log/process/calc-cars.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=process funargs=list(viz='CuyahogaShort') scripts=c('scripts/process/cuyahoga.R')" \
+vizlab/make/callFunction.R vizlab/make/log/process/CuyahogaShort.Rout
+
+process.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='visualize',outfile='vizlab/make/visualize.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/visualize.Rout
 make -f vizlab/make/visualize.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize')" \
-	vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')" \
-	vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-cars') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-cars.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='plot-iris') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/plot-iris.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=visualize funargs=list(viz='cuyahogaFig') scripts=c('scripts/visualize/visualize.R')" \
+vizlab/make/callFunction.R vizlab/make/log/visualize/cuyahogaFig.Rout
+
+visualize.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=createBlockMakefile funargs=list(block='publish',outfile='vizlab/make/publish.make')" \
+vizlab/make/callFunction.R vizlab/make/log/make/publish.Rout
 make -f vizlab/make/publish.make
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='index')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='cars-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='text-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='iris-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
-export R_LIBS_USER="/Users/wwatkins/Library/R/3.3/library";\
-	"/usr/local/bin/R" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='Cuyahoga-section')" \
-	vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout
+make[1]: Entering directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='index')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/index.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='cars-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/cars-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='text-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/text-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='iris-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/iris-section.Rout
+export R_LIBS_USER="C:/Users/aappling/Documents/R/win-library/3.3";\
+"C:/Program Files/R/R-3.3.2/bin/x64/R.exe" CMD BATCH --no-timing --quiet --no-save --no-restore "--args fun=publish funargs=list(viz='Cuyahoga-section')" \
+vizlab/make/callFunction.R vizlab/make/log/publish/Cuyahoga-section.Rout
+
+publish.make looks OK!
+
+make[1]: Leaving directory `/cygdrive/c/Users/aappling/Documents/GitHub/DS Vizzies/vizlab-example'
 ```
 This will call the main makefile, which in turn calls the makefile for each section.  The finished HTML will be created in the `target` directory, along with its corresponding CSS and images for each figure.  
 


### PR DESCRIPTION
@wdwatkins - review? Addressing #82. The functional changes are all in R/createMakefiles.R: I'm creating a warning that appears in the shell when calling `make` if any viz.yaml items have a `scripts:` dependency that's a directory rather than a file. All the changes in other files are documentation for that one functional change.

I'm about to submit a parallel PR for USGS-VIZLAB/example - would be great if you could review these together.

See recent comments in #82, plus the new output in the vignette, for examples of how this works.