### PR TITLE
thumbnails will work now??

### DIFF
--- a/R/publishLandingPage.R
+++ b/R/publishLandingPage.R
@@ -66,8 +66,9 @@ getVizInfo <- function(org, repo){
                             template="templates/vizzies.mustache",
                             publisher="section",
                             context=list(name=viz_info$name,
-                                         thumbnail=file.path(getVizUrl(viz_info$path),
-                                                             getVizUrl(viz_info$`thumbnail-landing`$url)),
+                                         thumbnail=paste(getVizUrl(viz_info$path),
+                                                         getVizUrl(viz_info$`thumbnail-landing`$url),
+                                                         sep='/'),
                                          alttext=viz_info$`thumbnail-landing`$alttext,
                                          path=getVizUrl(viz_info$path),
                                          description=viz_info$description))

--- a/R/publishLandingPage.R
+++ b/R/publishLandingPage.R
@@ -66,7 +66,8 @@ getVizInfo <- function(org, repo){
                             template="templates/vizzies.mustache",
                             publisher="section",
                             context=list(name=viz_info$name,
-                                         thumbnail=getVizUrl(viz_info$`thumbnail-landing`$url),
+                                         thumbnail=file.path(getVizUrl(viz_info$path),
+                                                             getVizUrl(viz_info$`thumbnail-landing`$url)),
                                          alttext=viz_info$`thumbnail-landing`$alttext,
                                          path=getVizUrl(viz_info$path),
                                          description=viz_info$description))


### PR DESCRIPTION
@jiwalker-usgs thumbnails are still broken, I think this fixes it. It should be relative to vizlab, so it needs the correct viz before the thumbnail path. Can't really test locally though, so hopefully I can see this on dev after I merge and it's deployed.