### PR TITLE
fix typo in vignette (install.github -> install_github)

### DIFF
--- a/inst/doc/vizlabExample.R
+++ b/inst/doc/vizlabExample.R
@@ -3,5 +3,5 @@ library(rmarkdown)
 
 ## ----eval=FALSE----------------------------------------------------------
 #  install.packages('devtools')
-#  devtools::install.github('USGS-VIZLAB/vizlab')
+#  devtools::install_github('USGS-VIZLAB/vizlab')
 

--- a/inst/doc/vizlabExample.Rmd
+++ b/inst/doc/vizlabExample.Rmd
@@ -23,7 +23,7 @@ library(rmarkdown)
 Vizlab can be downloaded from github via `devtools`:
 ```{r eval=FALSE}
 install.packages('devtools')
-devtools::install.github('USGS-VIZLAB/vizlab')
+devtools::install_github('USGS-VIZLAB/vizlab')
 ```
 
 The example visualization ('viz') is located at [https://github.com/USGS-VIZLAB/example](https://github.com/USGS-VIZLAB/example) and should be cloned into a separate directory.  

--- a/inst/doc/vizlabExample.html
+++ b/inst/doc/vizlabExample.html
@@ -12,7 +12,7 @@
 
 <meta name="author" content="David Watkins" />
 
-<meta name="date" content="2016-11-21" />
+<meta name="date" content="2017-01-06" />
 
 <title>Vizlab Example</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Vizlab Example</h1>
 <h4 class="author"><em>David Watkins</em></h4>
-<h4 class="date"><em>2016-11-21</em></h4>
+<h4 class="date"><em>2017-01-06</em></h4>
 
 
 
@@ -83,7 +83,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <h2>Installation</h2>
 <p>Vizlab can be downloaded from github via <code>devtools</code>:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">install.packages</span>(<span class="st">'devtools'</span>)
-devtools::<span class="kw">install.github</span>(<span class="st">'USGS-VIZLAB/vizlab'</span>)</code></pre></div>
+devtools::<span class="kw">install_github</span>(<span class="st">'USGS-VIZLAB/vizlab'</span>)</code></pre></div>
 <p>The example visualization (‘viz’) is located at <a href="https://github.com/USGS-VIZLAB/example" class="uri">https://github.com/USGS-VIZLAB/example</a> and should be cloned into a separate directory.</p>
 <p>To build the example viz, your working directory should be set to the main example directory, and the <code>vizlab</code> package should be loaded.</p>
 </div>

--- a/vignettes/vizlabExample.Rmd
+++ b/vignettes/vizlabExample.Rmd
@@ -23,7 +23,7 @@ library(rmarkdown)
 Vizlab can be downloaded from github via `devtools`:
 ```{r eval=FALSE}
 install.packages('devtools')
-devtools::install.github('USGS-VIZLAB/vizlab')
+devtools::install_github('USGS-VIZLAB/vizlab')
 ```
 
 The example visualization ('viz') is located at [https://github.com/USGS-VIZLAB/example](https://github.com/USGS-VIZLAB/example) and should be cloned into a separate directory.  


### PR DESCRIPTION
Typo pointed out by a potential user - thanks, Jonathan!