### PR TITLE
reduce fragility of needsTimestamp()

### DIFF
--- a/R/createMakefiles.R
+++ b/R/createMakefiles.R
@@ -432,8 +432,11 @@ needsTimestamp <- function(item.info) {
   # the viz item (see next code block).
   FT_method <- paste0('fetchTimestamp.', item.info$fetcher)
   # (1) search through the text of the item's declared scripts
-  FT_in_scripts <- if(length(item.info$scripts) > 0) {
-    script_text <- unlist(lapply(item.info$scripts, function(script) {
+  scripts <- unlist(sapply(item.info$scripts, function(sdep) {
+    if(dir.exists(sdep)) dir(sdep, full.names = TRUE) else sdep
+  }))
+  FT_in_scripts <- if(length(scripts) > 0) {
+    script_text <- unlist(lapply(scripts, function(script) {
       deparse(parse(script)) # use deparse to get rid of commented-out code
     }))
     any(grep(FT_method, script_text, fixed=TRUE))


### PR DESCRIPTION
it's still a fragile function, but this change helps with a new bug (my bad, from last sprint) in creating makefiles when one or more items have a directory as a `scripts:` dependency. the error in example/vizlab/make/log/make/fetch.Rout was this:
```
> # Call function
> message("Running function")
Running function
> do.call(cmd.args$fun, if(is.null(cmd.args$funargs)) list() else cmd.args$funargs)
Error in file(filename, "r") : cannot open the connection
Calls: do.call ... unlist -> lapply -> FUN -> deparse -> parse -> file
In addition: Warning message:
In file(filename, "r") :
  cannot open file 'scripts/fetch': Permission denied
Execution halted
```
but with this PR the function now only tries to parse files, not directories - works much better.