### PR TITLE
#253 favicon for landing page

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -320,7 +320,7 @@ publish.landing <- function(viz){
   pageviz$depends <- as.list(pageviz$depends)
   pageviz$depends <- append(pageviz$depends, viz_info)
   pageviz$context <- list(sections = c("owiNav", "header", names(viz_info)), #names of section ids
-                          resources = c("landingCSS", "owiCSS", "jquery", "appJS"),
+                          resources = c("lib-vizlab-favicon", "landingCSS", "owiCSS", "jquery", "appJS"),
                           header = "usgsHeader",
                           footer = "usgsFooter", 
                           info = list(`analytics-id` = "UA-78530187-11"))

--- a/inst/landing/viz.yaml
+++ b/inst/landing/viz.yaml
@@ -124,4 +124,7 @@ publish:
     template: fullpage
     publisher: landing
     org: USGS-VIZLAB
-    depends: [usgsHeader, owiNav, header, usgsFooter, thumbnail, usgsLogo, usgsBanner, jquery, appJS, landingCSS, owiCSS]
+    depends: ["lib-vizlab-favicon", "usgsHeader", "owiNav", "header", "usgsFooter", "thumbnail", "usgsLogo", 
+      "usgsBanner", "jquery", "appJS", "landingCSS", "owiCSS"]
+    context:
+      resources: ["lib-vizlab-favicon", "jquery", "appJS", "landingCSS", "owiCSS"]


### PR DESCRIPTION
Added the vizlab favicon to the landing page publisher and to the landing page viz.yaml.  The favicon is in the vizlab resources yaml, so was pretty easy to call out to.