### PR TITLE
Validate viz yaml

### DIFF
--- a/R/validateVizYaml.R
+++ b/R/validateVizYaml.R
@@ -4,7 +4,7 @@
 validateVizYaml <- function() {
   viz.items <- getContentInfos()
   
-  # require that ids have no spaces or dashes in them
+  # require that ids are always present and have no spaces, dashes, etc. in them
   for(i in seq_along(viz.items)) {
     id <- viz.items[[i]]$id
     if(is.null(id)) {
@@ -27,5 +27,4 @@ validateVizYaml <- function() {
   # require that item locations are in data, cache/fetch, cache/process, cache/visualize, or 
   #   maybe external to visualization directory (?)
   # etc.
-  warning("this function currently doesn't do any checking")
 }

--- a/R/validateVizYaml.R
+++ b/R/validateVizYaml.R
@@ -2,11 +2,28 @@
 #' 
 #' @export
 validateVizYaml <- function() {
-  # require that ids have no spaces in them,
-  # require that locations have no spaces in them (i think make requires this),
-  # require that expected sections exist,
-  # require taht unexpected sections don't exist,
-  # require that mimeTypes are real mimeTypes,
+  viz.items <- getContentInfos()
+  
+  # require that ids have no spaces or dashes in them
+  for(i in seq_along(viz.items)) {
+    id <- viz.items[[i]]$id
+    if(is.null(id)) {
+      stop(paste0("missing or null viz item id in ", i, "th item"))
+    } else {
+      parsed <- tryCatch(
+        parse(text=id),
+        error=function(e) {
+          stop(paste0("unparseable viz item id: ", id))
+        })
+      if(length(parsed[[1]]) > 1) {
+        stop(paste0("viz item id parses to >1 R variable name: ", id))  
+      }
+    }
+  }
+  
+  # require that expected sections exist
+  # require taht unexpected sections don't exist
+  # require that mimeTypes are real mimeTypes
   # require that item locations are in data, cache/fetch, cache/process, cache/visualize, or 
   #   maybe external to visualization directory (?)
   # etc.


### PR DESCRIPTION
Added a check to `validateVizYaml()`, which has been a placeholder function for a long time. `validateVizYaml()` doesn't automatically get called yet, but I have plans for that. And maybe eventually we'll add other checks as well. This PR introduces checks for (1) missing viz IDs, (2) viz IDs that can't be parsed by R at all, and (3) viz IDs that get parsed to more than one R object (e.g., "plot-cars" gets parsed to c("plot", "-", "cars"), which is no good if we're going to use IDs as R variable names).

Applied to the current USGS-VIZLAB/example repo, this will produce the same type of error for every id because they're all currently dash-separated:
```
viz item id parses to >1 R variable name: plot-info
```