### PR TITLE
first cut at createRemakefile

### DIFF
--- a/R/createRemakefile.R
+++ b/R/createRemakefile.R
@@ -1,0 +1,122 @@
+createRemakefile <- function() {
+  
+  # get header information
+  info.yml <- getBlocks('info', FALSE)[[1]]
+  file.extensions <- info.yml$'file-extensions' # will often be NULL, which is fine
+  packages <- names(info.yml$'required-packages')
+  
+  # read all the viz item info, which we'll use a few times below
+  viz.items <- getContentInfos()
+  
+  # pull sources (scripts) from all vizyaml items
+  script.deps <- unique(unlist(lapply(unname(viz.items), `[[`, 'scripts')))
+  script.dirs <- script.deps[sapply(script.deps, dir.exists)]
+  script.files <- script.deps[sapply(script.deps, function(dep) { !dir.exists(dep) && file.exists(dep) })]
+  script.missing <- setdiff(script.deps, c(script.dirs, script.files))
+  if(length(script.missing) > 0) {
+    stop('missing scripts: ', paste0(script.missing, collapse=', '))
+  }
+  sources <- sort(unique(c(
+    dir(script.dirs, full.names=TRUE),
+    script.files
+  )))
+  
+  # create the main list of targets, one per viz item
+  viz.targets <- lapply(viz.items, function(viz.item) {
+    # if there is no location, that means this is an R object target
+    viz.item$target <- if(viz.item$block == 'resource') {
+      destloc <- file.path("target", viz.item$location)
+      destloc <- gsub('js/third-party', 'js', destloc)
+      paste0("'", destloc, "'")
+    } else if(exists('location', viz.item)) {
+      # if the target is a file, surround it in quotes in case the filename has spaces, etc.
+      paste0("'", viz.item$location, "'")
+    } else {
+      # if the target is an R object, use the id as the variable (target) name
+      viz.item$id
+    }
+    return(viz.item)
+  })
+  # extract vectors of item IDs and block names corresponding to the elements of viz.targets
+  item.ids <- unlist(lapply(viz.targets, `[[`, 'id'))
+  block.names <- unlist(lapply(viz.targets, `[[`, 'block'))
+  # create a nested list of items (targets) within each block. the unname()
+  # calls are important for whisker::whisker.render
+  blocks <- lapply(unique(block.names), function(block.name) {
+    items <- viz.targets[names(block.names[block.names == block.name])]
+    recipes <- lapply(unname(items), function(item) {
+      recipe <- list(
+        id = item$id, # just copy for fun, or maybe we'll use this as a comment in the makefile...
+        target_name = item$target,
+        depends = lapply(unname(item$depends), function(dep) {
+          dep.item <- viz.targets[[names(item.ids[item.ids == dep])]]
+          dep.item$target
+        }),
+        command = paste0(
+          if(item$block == 'resource') 'publish' else item$block, # except for resource, the block name is the function name
+          "(I('", item$id, "'))")
+      )
+      if(length(recipe$depends) == 0) recipe$depends <- NULL
+      recipe$has_depends <- exists('depends', recipe)
+      return(recipe)
+    })
+    block <- list(block=block.name, recipes=recipes)
+    return(block)
+  })
+  
+  # amend the resource block to have special commands and only include those
+  # resources that actually get used. first determine which resource targets
+  # actually get used
+  all.deps <- unlist(lapply(blocks, function(block) {
+    if(block$block == 'resource') {
+      NULL
+    } else {
+      lapply(block$recipes, function(recipe) {
+        recipe$depends
+      })
+    }
+  }), recursive=TRUE)
+  all.resources <- viz.targets[sapply(viz.targets, function(item) item$block == 'resource')]
+  resource.targets <- sapply(unname(all.resources), `[[`, 'target')
+  resource.deps <- intersect(all.deps, resource.targets)
+  # extract, amend, and replace the resource block
+  resource.block.index <- which(sapply(blocks, function(block) block$block == 'resource'))
+  resource.recipes <- blocks[[resource.block.index]]$recipes
+  # filter to just those that are used
+  resource.recipes <- resource.recipes[sapply(resource.recipes, function(item) item$target_name %in% resource.deps)]
+  # replace the list in blocks with this shortened list
+  blocks[[resource.block.index]]$recipes <- resource.recipes
+  
+  # create the list of grouped targets (one for each block, one for the entire
+  # viz). can't just make the entire-viz group depend on the block groups
+  # because https://github.com/richfitz/remake/issues/129
+  final.targets <- viz.targets[sapply(viz.targets, function(item) {
+    item$block != 'resource' || item$target %in% resource.deps
+  })]
+  final.target_names <- unname(unlist(lapply(final.targets, `[[`, 'target')))
+  job_groups <- list(
+    list(
+      target_name='viz',
+      depends=as.list(final.target_names))
+  )
+  
+  # combine and prepare the information for templating. add some booleans
+  # (has_xxx) to turn entire remake.yml sections on or off
+  viz <- list(
+    file_extensions = as.list(file.extensions),
+    has_file_extensions = length(file.extensions) > 0,
+    packages = as.list(packages),
+    sources = as.list(sources),
+    has_sources = length(sources) > 0,
+    blocks = blocks,
+    job_groups = job_groups
+  )
+  
+  # create the remake.yml from the template
+  template <- readLines('../vizlab/inst/remake/remake.mustache') #system.file('remake/remake.mustache', package='vizlab')
+  remake.yml <- whisker::whisker.render(template=template, data=viz)
+  writeLines(remake.yml, 'remake.yaml') # use .yaml to stay consistent with vizlab
+  
+  #cat(readLines('remake.yaml'), sep='\n')
+  return()
+}


### PR DESCRIPTION
First cut at createRemakefile() function.
* After running `createRemakefile()` in USGS-VIZLAB/example, it's [mostly] possible to run `remake::make(remake_file='remake.yaml')` and build the entire example project! That makes for a good start on #246.
* The [mostly] caveat from the previous bullet is that when I run `remake::make(remake_file='remake.yaml')` in a fresh session, things break unless I manually source those files listed in `sources:`. Why would this be? I don't understand.
* Creates a single remake.yaml for all of the blocks, and looks for cross references in any phase (not just the current one), so also addresses #88 (but testing would be nice)
* Includes recipes for those resources that are depended on by other targets, so also addresses #215 (but are these resources now getting copied over twice, once by `remake` and once by `vizlab`? more inspection & testing needed here, too)
* Does not yet reproduce the work done for #193 (depending on the viz.yaml blocks). This can be slick once we implement it, because the dependencies can be R objects instead of files, but there's nothing there yet. 
* Does not yet implement timestamp handling for `fetch` - just calls `fetch` on every item.
* There's a job group (group target) for the overall viz, but I'd still like to add job groups for `fetch`, `process`, etc. individually

Here's the remake.yaml that gets built for USGS-VIZLAB/example using this PR:
```yml
# Do not edit - automatically generated
# from the vizlab remake.mustache template

target_default: viz

packages:
  - vizlab
  - dplyr
  - dataRetrieval

sources:
  - scripts/fetch/cars.R
  - scripts/process/cars.R
  - scripts/process/cuyahoga.R
  - scripts/visualize/visualize.R


targets:

  # --- parameter --- #
  
  plot-info:
    command: parameter(I('plot-info'))

  color-stuff:
    command: parameter(I('color-stuff'))

  # --- fetch --- #
  
  'data/iris.csv':
    command: fetch(I('iris-data'))

  'cache/cars.csv':
    command: fetch(I('cars-data'))

  'cache/fetch/CuyahogaTDS.csv':
    command: fetch(I('Cuyahoga'))

  'data/markdownText.yaml':
    command: fetch(I('markdown-text'))

  # --- process --- #
  
  'cache/car-loess.rds':
    command: process(I('calc-cars'))
    depends:
      - 'cache/cars.csv'

  'cache/process/CuyahogaShort.tsv':
    command: process(I('CuyahogaShort'))
    depends:
      - 'cache/fetch/CuyahogaTDS.csv'

  # --- visualize --- #
  
  'figures/cars.png':
    command: visualize(I('plot-cars'))
    depends:
      - 'cache/car-loess.rds'
      - 'cache/cars.csv'
      - plot-info

  'figures/iris.png':
    command: visualize(I('plot-iris'))
    depends:
      - 'data/iris.csv'

  'figures/cuyahogaFig.svg':
    command: visualize(I('cuyahogaFig'))
    depends:
      - 'cache/process/CuyahogaShort.tsv'
      - color-stuff

  # --- publish --- #
  
  index:
    command: publish(I('index'))
    depends:
      - sourcesansprofont
      - cars-section
      - social-section
      - vertical-social-section
      - footer-section
      - header-section
      - 'layout/css/main.css'
      - text-section
      - iris-section
      - Cuyahoga-section
      - markdown-section1
      - markdown-section2
      - 'target/css/footer.css'
      - 'target/css/header.css'
      - 'target/css/socialMedia.css'
      - 'target/js/jquery-3.2.1.min.js'
      - 'target/js/svg-injector-1.1.3.min.js'
      - 'target/js/vizlab.js'

  cars-section:
    command: publish(I('cars-section'))
    depends:
      - 'figures/cars.png'

  text-section:
    command: publish(I('text-section'))

  markdown-section1:
    command: publish(I('markdown-section1'))
    depends:
      - 'data/markdownText.yaml'

  markdown-section2:
    command: publish(I('markdown-section2'))
    depends:
      - 'data/markdownText.yaml'

  iris-section:
    command: publish(I('iris-section'))
    depends:
      - 'figures/iris.png'

  Cuyahoga-section:
    command: publish(I('Cuyahoga-section'))
    depends:
      - 'figures/cuyahogaFig.svg'

  'layout/css/main.css':
    command: publish(I('figure-style'))

  social-section:
    command: publish(I('social-section'))
    depends:
      - 'target/css/socialMedia.css'

  vertical-social-section:
    command: publish(I('vertical-social-section'))
    depends:
      - 'target/css/socialMedia.css'

  header-section:
    command: publish(I('header-section'))
    depends:
      - 'target/images/usgsLogo.png'

  footer-section:
    command: publish(I('footer-section'))
    depends:
      - 'target/css/footer.css'

  sourcesansprofont:
    command: publish(I('sourcesansprofont'))

  # --- resource --- #
  
  'target/images/usgsLogo.png':
    command: publish(I('lib-usgs-logo'))

  'target/js/vizlab.js':
    command: publish(I('lib-vizlab-javascript'))

  'target/css/header.css':
    command: publish(I('lib-header-css'))

  'target/css/footer.css':
    command: publish(I('lib-footer-css'))

  'target/css/socialMedia.css':
    command: publish(I('lib-social-media-css'))

  'target/js/svg-injector-1.1.3.min.js':
    command: publish(I('lib-svg-injector-js'))

  'target/js/jquery-3.2.1.min.js':
    command: publish(I('lib-jquery-js'))



  # --- Job groups --- #

  viz:
    depends: 
      - plot-info
      - color-stuff
      - 'data/iris.csv'
      - 'cache/cars.csv'
      - 'cache/fetch/CuyahogaTDS.csv'
      - 'data/markdownText.yaml'
      - 'cache/car-loess.rds'
      - 'cache/process/CuyahogaShort.tsv'
      - 'figures/cars.png'
      - 'figures/iris.png'
      - 'figures/cuyahogaFig.svg'
      - index
      - cars-section
      - text-section
      - markdown-section1
      - markdown-section2
      - iris-section
      - Cuyahoga-section
      - 'layout/css/main.css'
      - social-section
      - vertical-social-section
      - header-section
      - footer-section
      - sourcesansprofont
      - 'target/images/usgsLogo.png'
      - 'target/js/vizlab.js'
      - 'target/css/header.css'
      - 'target/css/footer.css'
      - 'target/css/socialMedia.css'
      - 'target/js/svg-injector-1.1.3.min.js'
      - 'target/js/jquery-3.2.1.min.js'
```