### PR TITLE
Remove OWI logo from vizlab landing page

### DIFF
--- a/inst/landing/css/owi.css
+++ b/inst/landing/css/owi.css
@@ -38,14 +38,6 @@ nav ul a li {
   position:relative;
 }
 
-#owiLogoSmall{
-    position:absolute;
-    left:10px;
-    top:3px;
-    display:block;
-    width:47px;
-}
-
 #menu{
     background:#003366;
     width:80px;
@@ -122,12 +114,6 @@ nav ul a li {
     width: 768px;
     height: 40px;
     margin: 0 auto;
-  }
-  #owiLogoSmall {
-    display: block;
-    width: 47px;
-    position: absolute;
-    top: 3px;
   }
   
 /*========usgs-footer========*/

--- a/inst/landing/templates/owiNav.mustache
+++ b/inst/landing/templates/owiNav.mustache
@@ -6,10 +6,6 @@
             Menu
         </div>
 
-        <a href="https://owi.usgs.gov/">
-            <img id="owiLogoSmall" src="images/small-blue.png"/>
-        </a>
-
         <ul id="navigation">
             <a id="people" href="https://owi.usgs.gov/people/"><li>People</li></a>
             <a href="https://owi.usgs.gov/products/"><li>Products</li></a>

--- a/inst/landing/viz.yaml
+++ b/inst/landing/viz.yaml
@@ -58,12 +58,6 @@ publish:
     alttext: USGS banner
     title: USGS banner
   -
-    id: owiLogo
-    location: img/small-blue.png
-    mimetype: image/png
-    alttext: OWI Logo
-    title: OWI Logo
-  -
     id: mobileBurger
     location: img/mobileburger.png
     mimetype: image/png
@@ -103,7 +97,7 @@ publish:
     id: owiNav
     template: templates/owiNav.mustache
     publisher: section
-    depends: [owiLogo, mobileBurger]
+    depends: [mobileBurger]
   -
     id: usgsFooter
     template: templates/usgsFooter.mustache


### PR DESCRIPTION
Currently just deleted the logo instead of replacing with anything - can wait on the I2D2 logo. I left the banner because the menu button is still there. Closes #255 

![image](https://user-images.githubusercontent.com/15788176/31738683-15e0a038-b411-11e7-8114-1c3b53d33967.png)


