### PR TITLE
add gif as img mimetype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.2.2.9004
+Version: 0.2.2.9005
 Date: 2017-10-16
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>

--- a/inst/mimetypes.default.yaml
+++ b/inst/mimetypes.default.yaml
@@ -17,6 +17,7 @@ svg:
 img:
   - "image/png"
   - "image/jpg"
+  - "image/gif"
 ico:
   - "image/ico"
 js:


### PR DESCRIPTION
Related to the issue described in https://github.com/USGS-VIZLAB/how-to-gdp/pull/28 where gifs would make it to target, but would not end up being used in `index.html`.