### PR TITLE
publish.json, publish.tabular, and simpler export, buildContext, and expandDependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.2.2.9008
-Date: 2018-01-09
+Version: 0.2.2.9009
+Date: 2018-01-13
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/R/export.R
+++ b/R/export.R
@@ -103,14 +103,15 @@ export.css <- function(viz) {
   return(file)
 }
 
-#' Default export, defaults to not export
+#' Default export. Used to default to not export, but Alison couldn't think of
+#' when that would be useful so changed the default to TRUE.
 #'
 #' @rdname export
 #' @export
 export.resource <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, FALSE)) {
+  if (doExport(viz, TRUE)) {
     file <- paste0(exportLocation(), "data/", basename(location))
   }
   return(file)

--- a/R/export.R
+++ b/R/export.R
@@ -28,7 +28,7 @@ export.page <- function(viz) {
   }
 
   file <- NULL
-  if (doExport(viz, default = TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), name, ".html")
   }
 
@@ -45,7 +45,7 @@ export.section <- function(viz) {
   }
   
   file <- NULL
-  if (doExport(viz, default = TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "embed/", name, ".html")
   }
   
@@ -57,7 +57,7 @@ export.section <- function(viz) {
 export.img <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "images/", basename(location))
   }
   return(file)
@@ -68,7 +68,7 @@ export.img <- function(viz) {
 export.ico <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "images/", basename(location))
   }
   return(file)
@@ -86,7 +86,7 @@ export.svg <- function(viz) {
 export.js <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "js/", basename(location))
   }
   return(file)
@@ -97,7 +97,7 @@ export.js <- function(viz) {
 export.css <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "css/", basename(location))
   }
   return(file)
@@ -111,7 +111,7 @@ export.css <- function(viz) {
 export.resource <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "data/", basename(location))
   }
   return(file)
@@ -123,7 +123,7 @@ export.resource <- function(viz) {
 export.thumbnail <- function(viz) {
   location <- viz[['location']]
   file <- NULL
-  if (doExport(viz, TRUE)) {
+  if (doExport(viz)) {
     file <- paste0(exportLocation(), "images/", basename(location))
   }
   return(file)
@@ -142,15 +142,16 @@ exportLocation <- function() {
 
 ### Private functions used to help in exporting
 
-#' Should export be performed
+#' Return logical declaring whether file export (copying to target) should be
+#' performed
 #'
-#'@param viz vizlab object
-#'@param default logical for default export if not specified
-#'@return logical should this object be exported
-doExport <- function(viz, default){
-  do.export <- default
+#' @param viz vizlab object
+#' @param default logical for default export if not specified
+#' @return logical should this object be exported
+doExport <- function(viz, default=TRUE){
   if ("export" %in% names(viz)) {
-    do.export <- viz[['export']]
+    viz[['export']]
+  } else {
+    default
   }
-  return(do.export)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -34,11 +34,15 @@ buildContext <- function(context, dependencies) {
   if (is.null(data)) {
     data <- list()
   }
-  else if (is.character(data)) {
-    data <- readData(data)
-  }
+  # It may be Alison's lack of imagination, but it sure looks like we should be
+  # able to guarantee before this call that context is always a list or NULL. If we have
+  # to bring back the next few lines, so be it, but I want a use case.
+  # else if (is.character(data)) {
+  #   data <- readData(data)
+  # }
 
-  # replace dependencies with contents
+  # replace dependencies (context names) with contents (usually html tags for
+  # script, link, etc.)
   data <- rapply(data, function(x) {
     dep.ids <- x %in% names(dependencies)
     if (any(dep.ids)) {

--- a/R/util.R
+++ b/R/util.R
@@ -54,17 +54,27 @@ buildContext <- function(context, dependencies) {
   return(data)
 }
 
-#' Private function to expand dependencies by appropriately publishing
-#' or reading
+#' Private function to publish a dependency. Returns either the output of
+#' publish or the result of readData on the output of publish
+#'
+#' Cases when you'd want to return the output of publish(): dependency x is a
+#' javascript library or css file to be referenced in a <script> or <link> tag
+#' in <head>
+#'
+#' Cases when you'd want to return the output of readData(publish()): ???.
+#' Alison can't guess the use case and so is going to take out this option on
+#' 1/13/18. If we encounter a case when we need the reading option, we will
+#' change this function back and document the use case here. And if we last a
+#' long time without needing this option, we should delete expandDependencies()
+#' and just use publish() directly in the call from gatherDependencyList().
 #'
 #' @param x item to expand
 expandDependencies <- function(x) {
-  expanded.dep <- NULL
   expanded.dep <- publish(x)
-  if (is.list(expanded.dep) && !is.null(expanded.dep[['reader']])) {
-    expanded.dep <- as.reader(expanded.dep)
-    expanded.dep <- readData(expanded.dep)
-  }
+  # if (is.list(expanded.dep) && !is.null(expanded.dep[['reader']])) {
+  #   expanded.dep <- as.reader(expanded.dep)
+  #   expanded.dep <- readData(expanded.dep)
+  # }
   return(expanded.dep)
 }
 

--- a/inst/mimetypes.default.yaml
+++ b/inst/mimetypes.default.yaml
@@ -25,5 +25,6 @@ js:
   - "text/javascript"
 json:
   - "application/json"
+  - "application/geo+json"
 css:
   - "text/css"

--- a/inst/viz.defaults.yaml
+++ b/inst/viz.defaults.yaml
@@ -1,16 +1,11 @@
 images:
-  -
-    export: false
 fetch:
   -
     fetcher: file
     scripts: scripts/fetch
-    export: false
 process:
   -
     scripts: scripts/process
-    export: false
 visualize:
   -
     scripts: scripts/visualize
-    export: true


### PR DESCRIPTION
This PR primarily resolves #263, which requests a publish.json method. I also added a publish.tabular method because both are needs for using d3 (or jquery) for more complex javascript-side data viz, and because the two methods are identical. 

The final paragraph in the description of issue #263 suggests that publish.json should include a call to `export`; this is accomplished by the call to `NextMethod`, which will resolve to `publish.resource`, which calls `export` and also (importantly!) copies the file into `target/data`.

Partly to make the file copying happen, and partly because I can't think of cases where file copying *shouldn't* happen, I've made the default in `export.resource` be for doExport to be TRUE. This allowed me to simplify the use and implementation of `doExport` throughout `export.R`. (I think there are further simplifications we could make to the `export` function family in the future, but this change is enough for one day.)

There were two places where defaults were getting set for the `export` parameter: in `doExport` and also in `inst/viz.defaults.yaml`, which affects how the viz.yaml is read in. I took out the `export` values in the latter file so that we could set values in just one place. I'm pretty sure the values set in viz.defaults.yaml were doing very little, or possibly even getting in the way.

While I was learning this area of the vizlab code, I had to look at `buildContext` and `expandDependencies` a bunch. I think they're more complex than necessary and am taking that gamble here by simplifying them. If I'm wrong and the reviewer of this PR also doesn't catch it, I expect we'll catch it soon enough when a bug comes up. You can blame me then (I even put my name in the code where I took out the functionality).