### PR TITLE
point CuyahogaTDS.csv to new public item

### DIFF
--- a/tests/testthat/tests-timestamps.R
+++ b/tests/testthat/tests-timestamps.R
@@ -115,7 +115,7 @@ test_that("sciencebase works",{
   expect_true(file.exists(tsfile))
   ts1 <- readTimestamp('cuyahoga_sb')
   # check against the known timestamp for the cuyahoga_sb file
-  expect_equal(ts1, as.POSIXct("2016-06-12 15:50:15", tz="UTC"))
+  expect_equal(ts1, as.POSIXct("2018-02-13 16:08:48", tz="UTC"))
   
   # fetch timestamp and expect the mtime and the ts contents to stay the same
   mt1 <- file.mtime(tsfile)

--- a/tests/testthat/tests-timestamps.R
+++ b/tests/testthat/tests-timestamps.R
@@ -102,7 +102,7 @@ test_that("sciencebase works",{
     id='cuyahoga_sb',
     location='cache/fetch/cuyahoga_sb.csv',
     fetcher='sciencebase',
-    remoteItemId='575d839ee4b04f417c2a03fe',
+    remoteItemId='5a8309a7e4b00f54eb32959f',
     remoteFilename='CuyahogaTDS.csv',
     mimetype='text/csv')
   writeLines(yaml::as.yaml(viz.yaml), 'viz.yaml')  


### PR DESCRIPTION
try to fix the sciencebase errors from #327, which I think occur because sciencebase stopped allowing single-user accounts to have public items. the new remoteItemId points to https://www.sciencebase.gov/catalog/item/5a8309a7e4b00f54eb32959f in the new USGS-R Sandbox community (ScienceBase Catalog -> USGS-R Sandbox -> usgs-r-pkgs-tests -> vizlab), which is public.

probably won't fix all of #327, but i hope it's a start.