### PR TITLE
Social Media icon fix for all browsers

### DIFF
--- a/inst/css/socialMedia.css
+++ b/inst/css/socialMedia.css
@@ -38,7 +38,7 @@
 }
 
 .socialMediaImage img{
-  width: 100%;
+  width: 25px;
 }
 
 #github{


### PR DESCRIPTION
FireFox doesn't like SVG's to have width 100%, hence the social media Icons not showing up in their browser.  Width 25px should work on all browsers and we can just not have this issue next Viz and fix the current problem.