### PR TITLE
css suggestions for vizlab that came from how-to-gdp reviewer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.3.1
+Version: 0.3.2
 Date: 2018-02-28
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>

--- a/inst/css/footer.css
+++ b/inst/css/footer.css
@@ -72,16 +72,17 @@ footer a:active{
   min-height:20px;
 }
 
-#relatedItems h3,
-#relatedItems h4{
+.relatedItemsTitle,
+.relatedItemCaption{
   font-weight:400;
 }
 
-#relatedItems h3{
+.relatedItemsTitle{
   margin-bottom:10px;
+  font-size:1.17em;
 }
 
-#relatedItems h4{
+.relatedItemCaption h4{
   font-size:.9em;
 }
 

--- a/inst/css/header.css
+++ b/inst/css/header.css
@@ -7,13 +7,14 @@
 	font-family:"Source Sans Pro", sans-serif;
 	}
 	
-p {
+#header p {
   font-size:1.2em;
   line-height:1.5em;
 }
-#header h3{
-	padding-top:3px;
-	font-size:0.9em;
+
+#header h1{
+	padding-top:0px;
+	font-size:1.2em;
 	font-weight:400;
 	}
 	

--- a/inst/templates/footer.mustache
+++ b/inst/templates/footer.mustache
@@ -27,7 +27,7 @@
     <div id="relatedItems">
 
       <div id="relatedVizzies">
-        <h3>Related Visualizations:</h3>
+        <a class="relatedItemsTitle">Related Visualizations:</a>
         <div class="relatedItemContainer">
           {{#vizzies}}
         		<div class="relatedItem">
@@ -36,7 +36,7 @@
         					<img src="{{thumbLoc}}" alt=""/>
         				</div>
         			  <div class="titleHandler">
-        				  <h4>{{name}}</h4>
+        				  <a class="relatedItemCaption">{{name}}</a>
         				</div>
         			</a>
         		</div>

--- a/inst/templates/header.mustache
+++ b/inst/templates/header.mustache
@@ -4,6 +4,6 @@
     	  {{{usgsLogo}}}
     </a> 
   	
-  	<h3>{{ title }}</h3>
+  	<h1>{{ title }}</h1>
   </div>
 </div>


### PR DESCRIPTION
Ramona from TX WSC viz group had good tips about some the html tags we were using, including how using `<h3>` in the main header "will seriously discount that for automated crawlers in favor of the `<h1>`". That has now been adjusted :)