### PR TITLE
address testthat problems: redo from my how-to-gdp branch

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -457,9 +457,12 @@ publish.header <- function(viz) {
 #' @export
 publish.landing <- function(viz){
 
-  repos <- getRepoNames(viz[['org']])
-  viz_info <- lapply(repos, getVizInfo, org=viz[['org']], viz[['dev']])
-  names(viz_info) <- repos
+  repos <- setdiff(getRepoNames(viz[['org']]), c('vizlab', 'D3Learners', 'viz-scratch')) # we know some aren't vizzies
+  viz_info <- lapply(setNames(nm=repos), function(repo) {
+    tryCatch(getVizInfo(repo, org=viz[['org']], viz[['dev']]),
+             error=function(e) message(paste0("in getVizInfo(", repo, "): ", e$message), appendLF=TRUE),
+             warning=function(w) if(grepl("\\. is not a real", w$message)) return() else warning(w))
+  })
   # rm null
   viz_info <- viz_info[!sapply(viz_info, is.null)]
   # sort reverse chronological

--- a/R/publishLandingPage.R
+++ b/R/publishLandingPage.R
@@ -53,6 +53,9 @@ getVizInfo <- function(org, repo, dev){
     return()
   }
   
+  # the warning "NAs introduced by coercion: . is not a real" can be avoided by
+  # not setting any value to .; for example, in hurricane-harvey's data-sources
+  # item, we have "line6: .", which introduces this error.
   viz.yaml <- yaml.load_file(viz.yaml_url)
   
   has_publish_date <- !is.null(viz.yaml$info$`publish-date`)

--- a/tests/testthat/tests-publish.R
+++ b/tests/testthat/tests-publish.R
@@ -19,7 +19,13 @@ test_that("googlefont publisher is dispatched to", {
 })
 
 test_that("publish footer works", {
-  output <- publish('footer')
+  mock.get.repository.path <- function(org, repo, file) {
+    list(ok=TRUE, content=list(html_url=paste0('https://github.com/', org, '/', repo, '/blob/master/', file)))
+  }
+  with_mock(
+    `grithub::get.repository.path` = mock.get.repository.path, 
+    output <- publish('footer')
+  )
   expect_true(any(grepl('microplastics', output)))
   expect_true(any(grepl('https://owi.usgs.gov/blog/stats-service-map/', output)))
   expect_true(any(grepl('climate-change-walleye-bass', output)))
@@ -29,7 +35,10 @@ test_that("publish footer works", {
   fakeViz <- list(id="footer", publisher="footer", template = "footer-template", blogsInFooter=FALSE,
                   vizzies=list(list(name = "Microplastics in the Great Lakes", org="USGS-VIZLAB",
                                     repo = "great-lakes-microplastics")))
-  output <- publish(fakeViz)
+  with_mock(
+    `grithub::get.repository.path` = mock.get.repository.path, 
+    output <- publish(fakeViz)
+  )
   expect_true(any(grepl('microplastics', output)))
   expect_false(any(grepl('blog|Blogs', output)))
 })

--- a/tests/testthat/tests-publishLandingPage.R
+++ b/tests/testthat/tests-publishLandingPage.R
@@ -6,7 +6,8 @@ setuptmp <- setup()
 test_that("publishLandingPage works", {
 
   with_mock(
-    'vizlab:::getRepoNames' = function(org) { c("example", "great-lakes-microplastics", "climate-fish-habitat", "vizlab") },
+    `grithub::get.repository.path` = mock.get.repository.path, 
+    `vizlab:::getRepoNames` = function(org) { c("example", "great-lakes-microplastics", "climate-fish-habitat", "vizlab") },
     publishLandingPage()
   )
   index <- readLines('landing/target/index.html', warn = FALSE)

--- a/tests/testthat/tests-publishLandingPage.R
+++ b/tests/testthat/tests-publishLandingPage.R
@@ -4,7 +4,9 @@ oldwd <- getwd()
 setuptmp <- setup()
 
 test_that("publishLandingPage works", {
-
+  mock.get.repository.path <- function(org, repo, file) {
+    list(ok=TRUE, content=list(html_url=paste0('https://github.com/', org, '/', repo, '/blob/master/', file)))
+  }
   with_mock(
     `grithub::get.repository.path` = mock.get.repository.path, 
     `vizlab:::getRepoNames` = function(org) { c("example", "great-lakes-microplastics", "climate-fish-habitat", "vizlab") },

--- a/tests/testthat/tests-publishLandingPage.R
+++ b/tests/testthat/tests-publishLandingPage.R
@@ -5,7 +5,10 @@ setuptmp <- setup()
 
 test_that("publishLandingPage works", {
 
-  publishLandingPage()
+  with_mock(
+    'vizlab:::getRepoNames' = function(org) { c("example", "great-lakes-microplastics", "climate-fish-habitat", "vizlab") },
+    publishLandingPage()
+  )
   index <- readLines('landing/target/index.html', warn = FALSE)
 
   expect_true(any(grepl('microplastics', index)))

--- a/tests/testthat/tests-timestamps.R
+++ b/tests/testthat/tests-timestamps.R
@@ -12,10 +12,10 @@ test_that("alwaysCurrent doesn't get rebuilt unless missing", {
   expect_equal(fetchTimestamp.mayfly_nymph, alwaysCurrent)
   
   # first time: fetches
-  suppressWarnings(expect_message(vizmake('mayfly_nymph'), '[ BUILD ] data/mayfly_nymph.csv', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('mayfly_nymph'), '\\[ .*BUILD.* \\] data/mayfly_nymph.csv'))
   
   # after that: doesn't fetch
-  suppressWarnings(expect_message(vizmake('mayfly_nymph'), '[    OK ] mayfly_nymph', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('mayfly_nymph'), '\\[ .*OK.* \\] mayfly_nymph'))
 })
 
 test_that("locally outdated always gets built", {
@@ -28,15 +28,16 @@ test_that("locally outdated always gets built", {
 
 test_that("before time to live, even neverCurrent doesn't get rebuilt", {
   # first time: fetches
-  suppressWarnings(expect_message(vizmake('never_current'), '[ BUILD ] cache/fetch/never_current.txt', fixed=TRUE))
-  suppressWarnings(expect_message(vizmake('cuyahoga'), '[ BUILD ] cache/fetch/cuyahoga.csv', fixed=TRUE))
+  # the .* is needed in the following expect_message calls because of crayon package
+  suppressWarnings(expect_message(vizmake('never_current'), '\\[ .*BUILD.* \\] cache/fetch/never_current.txt'))
+  suppressWarnings(expect_message(vizmake('cuyahoga'), '\\[ .*BUILD.* \\] cache/fetch/cuyahoga.csv'))
   
   # put these fetch items within their timetolive intervals
   writeLines(yaml::as.yaml(list(timetolive=list(never_current='5 hours', cuyahoga='5 hours'))), 'preferences.yaml')
   
   # immediately after: doesn't fetch
-  suppressWarnings(expect_message(vizmake('never_current'), '[    OK ] cache/fetch/never_current.txt', fixed=TRUE))
-  suppressWarnings(expect_message(vizmake('cuyahoga'), '[    OK ] cache/fetch/cuyahoga.csv', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('never_current'), '\\[ .*OK.* \\] cache/fetch/never_current.txt'))
+  suppressWarnings(expect_message(vizmake('cuyahoga'), '\\[ .*OK.* \\] cache/fetch/cuyahoga.csv'))
 })
 
 test_that("after time to live, timestamp gets checked", {
@@ -50,23 +51,23 @@ test_that("after time to live, timestamp gets checked", {
   # never-current should have its timestamp refetched, and the new timestamp
   # should be different (iff we've waited at least 1 second)
   Sys.sleep(0.02)
-  suppressWarnings(expect_message(vizmake('never_current'), '[ BUILD ] vizlab/remake/timestamps/never_current.txt', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('never_current'), '\\[ .*BUILD.* \\] vizlab/remake/timestamps/never_current.txt'))
   expect_gt(as.numeric(readTimestamp('never_current')), as.numeric(nc_ts1))
   # after ttl expires, neverCurrent always fetches, even right (>1 sec) after it just fetched
   Sys.sleep(0.02)
-  suppressWarnings(expect_message(vizmake('never_current'), '[ BUILD ] cache/fetch/never_current.txt', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('never_current'), '\\[ .*BUILD.* \\] cache/fetch/never_current.txt'))
   
   # sometimes-current should have its timestamps refetched. here the new
   # timestamp should be the same (because of how we defined
   # fetchTimestamp.cuyahoga), so cuyahoga isn't refetched
-  suppressWarnings(expect_message(vizmake('cuyahoga'), '[ BUILD ] vizlab/remake/timestamps/cuyahoga.txt', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('cuyahoga'), '\\[ .*BUILD.* \\] vizlab/remake/timestamps/cuyahoga.txt'))
   expect_equal(readTimestamp('cuyahoga'), cy_ts1)
-  suppressWarnings(expect_message(vizmake('cuyahoga'), '[    OK ] cache/fetch/cuyahoga.csv', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('cuyahoga'), '\\[ .*OK.* \\] cache/fetch/cuyahoga.csv'))
   
   # if we change the remote timestamp for cuyahoga, the new timestamp should be
   # different and the item should get refetched
   Sys.setFileTime('data/pretend_remote/cuyahoga.csv', cy_ts1 + as.difftime(2, units='secs'))
-  suppressWarnings(expect_message(vizmake('cuyahoga'), '[ BUILD ] cache/fetch/cuyahoga.csv', fixed=TRUE))
+  suppressWarnings(expect_message(vizmake('cuyahoga'), '\\[ .*BUILD.* \\] cache/fetch/cuyahoga.csv'))
   expect_gt(as.numeric(readTimestamp('cuyahoga')), as.numeric(cy_ts1))
 })
 
@@ -77,7 +78,7 @@ cleanup(oldwd, testtmp)
 test_that(".url works", {
   testtmp <- setup(copyTestViz=TRUE)
   dir.create('vizlab/remake/timestamps', recursive=TRUE, showWarnings=FALSE)
-
+  
   tsfile <- locateTimestampFile('foo')
   expect_false(file.exists(tsfile))
   


### PR DESCRIPTION
should resolve, or help with, issue #327 and current test failures in #354. these issues include 

from #327:
```
1. Failure: alwaysCurrent doesn't get rebuilt unless missing (@tests-timestamps.R#15) 
`messages` does not match "[ BUILD ] data/mayfly_nymph.csv".
Actual values:
* [ \033[33m LOAD\033[39m ] \n
* (       ) vizlab/remake/timestamps/cuyahoga.txt\n
* (       ) vizlab/remake/timestamps/never_current.txt\n
* Starting build at 2018-01-10 10:00:39\n
* [ \033[33m READ\033[39m ]                                                |  \033[90m# loading sources\033[39m\n
* < \033[36m MAKE\033[39m > mayfly_nymph\n
* [ \033[34mBUILD\033[39m ] arguments_all                                  |  \033[90marguments_all <-...\033[39m\n
* [ \033[33m READ\033[39m ]                                                |  \033[90m# loading packages\033[39m\n
* [ \033[34mBUILD\033[39m ] arguments_mayfly_nymph                         |  \033[90marguments_mayfly...\033[39m\n
* [ \033[34mBUILD\033[39m ] vizlab/remake/scripts/mayfly_nymph.R           |  \033[90mprepSources(outf...\033[39m\n
* [ \033[34mBUILD\033[39m ] data/mayfly_nymph.csv                          |  \033[90mfetch("mayfly_ny...\033[39m\n
* fetching mayfly_nymph from data/mayfly_nymph.csv to data/mayfly_nymph.csv\n
* a mayfly is a kind of insect\n
* [ \033[34mBUILD\033[39m ] mayfly_nymph                                   |  \033[90mmayfly_nymph <- ...\033[39m\n
* Finished build at 2018-01-10 10:00:39\n


2. Failure: alwaysCurrent doesn't get rebuilt unless missing (@tests-timestamps.R#18) 
`messages` does not match "[    OK ] mayfly_nymph".
...
```
and more similar errors that i'm blaming on the new use of the crayon package by remake.

from #354:
```
> test_check("vizlab")
  ── 1. Failure: publishLandingPage works (@tests-publishLandingPage.R#11)  ──────
  any(grepl("microplastics", index)) isn't true.
  
  ── 2. Failure: publishLandingPage works (@tests-publishLandingPage.R#12)  ──────
  any(grepl("climate-change-walleye-bass", index)) isn't true.
  
  ══ testthat results  ═══════════════════════════════════════════════════════════
  OK: 128 SKIPPED: 2 FAILED: 2
  1. Failure: publishLandingPage works (@tests-publishLandingPage.R#11) 
  2. Failure: publishLandingPage works (@tests-publishLandingPage.R#12) 
```
where we think these publish errors come from spotty results returned from `grithub` calls.