### PR TITLE
css update title wrap + links in footer

### DIFF
--- a/inst/css/header.css
+++ b/inst/css/header.css
@@ -1,7 +1,7 @@
 #header{
 	background:rgb(0,51,102);
 	color:#fff;
-	height:32px;
+	height:auto;
 	padding:8px  0 0 10px;
 	border-bottom:5px solid rgb(210,210,210);
 	font-family:"Source Sans Pro", sans-serif;

--- a/inst/css/header.css
+++ b/inst/css/header.css
@@ -1,7 +1,7 @@
 #header{
 	background:rgb(0,51,102);
 	color:#fff;
-	height:auto;
+	height:32px;
 	padding:8px  0 0 10px;
 	border-bottom:5px solid rgb(210,210,210);
 	font-family:"Source Sans Pro", sans-serif;
@@ -24,3 +24,8 @@
 	width:80px;
 	}
 	
+@media screen and (max-width: 768px) {
+  #header h1 {
+    font-size:1em;
+  }
+}

--- a/inst/templates/footer.mustache
+++ b/inst/templates/footer.mustache
@@ -31,7 +31,7 @@
     <div id="related-items">
 
       <div id="relatedVizzies">
-        <a class="related-items-title">Related Visualizations:</a>
+        <p class="related-items-title">Related Visualizations:</p>
         <div class="related-items-container">
           {{#vizzies}}
         		<div class="related-item">
@@ -40,7 +40,7 @@
         					<img src="{{thumbLoc}}" alt=""/>
         				</div>
         			  <div class="titleHandler">
-        				  <a class="related-items-caption">{{name}}</a>
+        				  <a href="{{url}}" class="related-items-caption">{{name}}</a>
         				</div>
         			</a>
         		</div>


### PR DESCRIPTION
Still noticed some tiny details in how-to-gdp that would be useful for future vizzies. 

On mobile, the header words wrapped and disappeared:
![image](https://user-images.githubusercontent.com/13220910/37524440-d89fa884-28f7-11e8-8fa1-6591f651a001.png)

This fixes that:

![image](https://user-images.githubusercontent.com/13220910/37524424-cc27e7d8-28f7-11e8-93d5-f99747617d66.png)

Desktop remains the same:
![image](https://user-images.githubusercontent.com/13220910/37524474-f2878d98-28f7-11e8-94f9-c38b40e644d3.png)

Also in the footer, the title "Related Visualizations" looked and acted like a link but didn't link to anything, so changed the template. Same for the title of the related vizzie, but I added the URL to that since it should link.

No noticeable appearance, but underlines on hover only work for the ones with links now.
![image](https://user-images.githubusercontent.com/13220910/37524594-481630a2-28f8-11e8-8c79-52fd7542bce5.png)
