### PR TITLE
New secondary and main svg

### DIFF
--- a/inst/css/content.css
+++ b/inst/css/content.css
@@ -30,7 +30,7 @@ body {
 /*IE SVG Width Fix*/
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){
     .main-svg svg{
-      width: 100%;
+      width:100%;
       height:600px;
     }
     

--- a/inst/css/content.css
+++ b/inst/css/content.css
@@ -29,19 +29,24 @@ body {
 
 /*IE SVG Width Fix*/
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){
-    .svg-container svg{
-      width:100%;
-      height:608px;
+    .main-svg svg{
+      width: 100%;
+      height:600px;
     }
+    
+    .secondary-svg{
+      height:400px;
+    }
+
 }
 
 @media screen and (min-width: 1024px){
-  .svg-container,
+  .main-svg,
   .viz-text{
     width:960px;
   }
   
-  .svg-container{
+  .main-svg{
     margin:0 auto;
   }
   


### PR DESCRIPTION
So changed svg-container to main svg as it has the code for the big fancy interactive SVG.  The secondary was needed to avoid them inheriting the main-svg width CSS on Desktop. 

I think this works for now, but maybe some more thought needs to go into this for fixing IE and having the ability to do as many fancy SVG's as we want as easily as we can.