### PR TITLE
load usgs-analytics after the footer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,6 @@ Type: Package
 Title: Utilities for building online data visualizations
 Version: 0.3.5
 Date: 2018-05-11
->>>>>>> 2cf9258dc2df881e11f05195825e6f4801902cf6
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.3.4
-Date: 2018-04-24
+Version: 0.3.5
+Date: 2018-05-04
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/inst/templates/fullPage.mustache
+++ b/inst/templates/fullPage.mustache
@@ -13,7 +13,6 @@
   {{#info}}
     {{>semantics}}
         {{#analytics-id}}
-    <script type="application/javascript" async src="https://www2.usgs.gov/scripts/analytics/usgs-analytics.js"></script>
    
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
     <script>
@@ -47,11 +46,14 @@
 {{#sections }}
   {{{ . }}}
 {{/sections }}
+
 {{#footer}}
   <footer>
     {{{footer}}}
   </footer>
 {{/footer}}
+
+<script type="application/javascript" async src="https://www2.usgs.gov/scripts/analytics/usgs-analytics.js"></script>
 
 </body>
 


### PR DESCRIPTION
Fixes #374. Working on being smarter about where and when things are loaded. Moving the `usgs-analytics.js` after everything else on the page.

For water-use-15, it still doesn't load after the actual map data, but does load after all of the footer images (https://github.com/USGS-VIZLAB/water-use-15/issues/313 will work on lazy loading to let javascript stuff happen first).

Before
![image](https://user-images.githubusercontent.com/13220910/39648877-6849ee5e-4fa9-11e8-9c0f-7a7cbd4be633.png)

After
![image](https://user-images.githubusercontent.com/13220910/39648846-4942256c-4fa9-11e8-9db9-f8368b4288ce.png)
