### PR TITLE
Footer contrast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.3.5
-Date: 2018-05-11
+Version: 0.3.6
+Date: 2018-05-24
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/inst/css/footer.css
+++ b/inst/css/footer.css
@@ -9,6 +9,7 @@ footer{
 	}
 	
 footer a{
+	background:#414042;
   text-decoration:none;
 }
 	

--- a/inst/css/footer.css
+++ b/inst/css/footer.css
@@ -1,15 +1,15 @@
 footer{
-	background:#414042;
-	min-height:200px;
-	color:#fff;
-	border-top:5px solid rgb(210,210,210);
-	margin-top:20px;
-	font-family:"Source Sans Pro", sans-serif;
-	padding-bottom: 10px;
-	}
+  background:#414042;
+  min-height:200px;
+  color:#fff;
+  border-top:5px solid rgb(210,210,210);
+  margin-top:20px;
+  font-family:"Source Sans Pro", sans-serif;
+  padding-bottom: 10px;
+}
 	
 footer a{
-	background:#414042;
+  background:#414042;
   text-decoration:none;
 }
 	


### PR DESCRIPTION
adding `background:#414042;` to `footer a{}` css element to satisfy 508 contrast error about text links in footer (regular-view contrast looks fine, but contrast would fail if a browser displayed the page without some visual elements)

This change is required to fully resolve 508 errors as in https://github.com/USGS-VIZLAB/water-use-15/pull/351