### PR TITLE
Fixes what is on dev & brings Harvey/Irma back

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -460,12 +460,13 @@ publish.header <- function(viz) {
 #' @rdname publish
 #' @export
 publish.landing <- function(viz){
-
+  
   repos <- setdiff(getRepoNames(viz[['org']]), c('vizlab', 'D3Learners', 'viz-scratch')) # we know some aren't vizzies
   viz_info <- lapply(setNames(nm=repos), function(repo) {
     tryCatch(getVizInfo(repo, org=viz[['org']], viz[['dev']]),
-             error=function(e) message(paste0("in getVizInfo(", repo, "): ", e$message), appendLF=TRUE),
-             warning=function(w) if(grepl("\\. is not a real", w$message)) return() else warning(w))
+             error=function(e) message(paste0("in getVizInfo(", repo, "): ", e$message), appendLF=TRUE)
+             # warning=function(w) if(grepl("\\. is not a real", w$message)) return() else warning(w)
+             )
   })
   # rm null
   viz_info <- viz_info[!sapply(viz_info, is.null)]

--- a/R/publishLandingPage.R
+++ b/R/publishLandingPage.R
@@ -60,18 +60,20 @@ getVizInfo <- function(org, repo, dev){
   
   has_publish_date <- !is.null(viz.yaml$info$`publish-date`)
   if(has_publish_date) {
+    publish_date <- as.Date(viz.yaml$info$`publish-date`)
     if(!dev){
       # for prod, verify that the publish date is today or already past
-      publish_date <- as.Date(viz.yaml$info$`publish-date`)
       is_published <- publish_date <= Sys.Date()  
-      if(!is_published){
-        return()
-      } 
     } else {
       # for dev, publish anything that actually has a date in the field
       is_published <- TRUE
     }
   } else {
+    is_published <- FALSE
+  }
+  
+  if(!is_published){
+    # if it is not going to be published, jump out of this function
     return()
   }
   

--- a/R/publishLandingPage.R
+++ b/R/publishLandingPage.R
@@ -59,23 +59,22 @@ getVizInfo <- function(org, repo, dev){
   viz.yaml <- yaml.load_file(url(viz.yaml_url))
   
   has_publish_date <- !is.null(viz.yaml$info$`publish-date`)
-  if(!dev){
-    if(has_publish_date){
+  if(has_publish_date) {
+    if(!dev){
+      # for prod, verify that the publish date is today or already past
       publish_date <- as.Date(viz.yaml$info$`publish-date`)
       is_published <- publish_date <= Sys.Date()  
       if(!is_published){
         return()
       } 
     } else {
-      return()
+      # for dev, publish anything that actually has a date in the field
+      is_published <- TRUE
     }
   } else {
-    publish_date <- as.Date(viz.yaml$info$`publish-date`)
-    is_published <- TRUE
-    if(is.null(publish_date) | is.na(publish_date)){
-      publish_date <- Sys.Date()
-    }
+    return()
   }
+  
   viz_info <- viz.yaml$info
   
   viz_url <- viz_info$url


### PR DESCRIPTION
Edited how publish-date is used so that blank fields never get built, dev builds anything with a date past or future, and prod only builds dates that are today's date or in the past.

Fix for Harvey and Irma: We aren't sure why this was implemented, but commented it out for now. It does not break any tests when we do. https://github.com/USGS-VIZLAB/vizlab/commit/ef628bace5231525024026f63c3a5529cd5a879f

That is was was preventing Harvey and Irma from building because they get that warning due to https://github.com/USGS-VIZLAB/hurricane-harvey/blob/master/viz.yaml#L434 and https://github.com/USGS-VIZLAB/hurricane-irma/blob/master/viz.yaml#L696