### PR TITLE
kick off different webpack build configs for dev vs prod

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.3.8
-Date: 2018-08-07
+Version: 0.3.9
+Date: 2018-10-02
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont, David Watkins
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/R/vizmake.R
+++ b/R/vizmake.R
@@ -4,12 +4,15 @@
 #' a visualization.
 #' @param target_names names of targets to build, or NULL for the default, as
 #'   passed to `remake::make()`
+#' @param webpack_build_cfg character string indicating which script to run from the
+#'   webpack package.json file, e.g. "dev", "prod", "watch", etc. Must exist in 
+#'   the package.json file for your viz. Defaults to `start`.
 #' @param ... arguments passed to `remake::make()` (besides `target_names`,
 #'   above, or `remake_file`, which is fixed at 'remake.yaml')
 #' @md
 #' @export
-vizmake <- function(target_names=NULL, ...) {
-  
+vizmake <- function(target_names=NULL, webpack_build_cfg = "start", ...) {
+   
   # check the format of the viz.yaml (limited checks so far)
   validateVizYaml()
   
@@ -49,7 +52,7 @@ vizmake <- function(target_names=NULL, ...) {
   if(file.exists('webpack.config.js')) {
     # run webpack
     message('Running webpack ', Sys.time())
-    webpacker()
+    webpacker(webpack_build_cfg)
     message('Finished webpack ', Sys.time())
   }
   

--- a/R/webpacker.R
+++ b/R/webpacker.R
@@ -1,11 +1,13 @@
 #' Run webpack for the project
 #'
 #' This is called at the very end of `vizmake()` if you have a webpack block in your `viz.yaml`.
-#' @param webpack.config list containing at least an input and output element that contain a
-#' filepath for the javasript file going into webpack, and the name for the bundled file that results.
+#' @param webpack_cfg character string indicating which script to run from the
+#'   webpack package.json file, e.g. "dev", "prod", "watch", etc. Must exist in 
+#'   the package.json file for your viz. Defaults to `start`.
+#'   
 #' @md
 #' @export
-webpacker <- function() {
+webpacker <- function(webpack_build_cfg) {
   
   # check if node, npm are installed
   checkInstalled("node")
@@ -15,7 +17,7 @@ webpacker <- function() {
   checkAndInstallNodeModule("webpack-cli")
   
   ## have a way to fail if `start` is not the default?
-  system("npm run start")
+  system(paste("npm run", webpack_build_cfg))
 }
 
 #' Check that a system library is installed


### PR DESCRIPTION
Tested this with `gage-conditions`. The dev bundle.js was 1.2 MB and the beta bundle.js was 250 KB.

```
vizlab::vizmake(webpack_build_cfg = "dev") # uses webpack --mode development
vizlab::vizmake(webpack_build_cfg = "beta") # uses webpack --mode production
```