### PR TITLE
content.css addition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: vizlab
 Type: Package
 Title: Utilities for building online data visualizations
-Version: 0.3.9
-Date: 2018-10-02
+Version: 0.3.10
+Date: 2018-10-03
 Author: Jordan Walker, Alison Appling, Lindsay Carr, Luke Winslow, Jordan Read, Laura DeCicco, Marty Wernimont, David Watkins
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Provides utility functions to organize, develop, and publish

--- a/inst/css/content.css
+++ b/inst/css/content.css
@@ -1,3 +1,8 @@
+* {
+    padding: 0;
+    margin: 0;
+}
+
 body {
   font-family: sans-serif;
 }

--- a/inst/css/content.css
+++ b/inst/css/content.css
@@ -1,6 +1,7 @@
+
 * {
-    padding: 0;
-    margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 body {


### PR DESCRIPTION
Thanks to some quick screensharing with @mwernimont, we figured out why the header and footer spacing looked strange in `gage-conditions` (see https://github.com/USGS-VIZLAB/gage-conditions/issues/20). We updated `content.css` with the necessary style specs and increased the version.